### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui-lmstudio-image-to-text-node"
 description = "A custom node for ComfyUI that integrates LM Studio's vision models to generate text descriptions of images. It provides a flexible and customizable way to add image-to-text capabilities to your ComfyUI workflows, working with LM Studio's local API."
 version = "1.0.2"
-license = "LICENSE"
+license = { file = "LICENSE" }
 
 [project.urls]
 Repository = "https://github.com/mattjohnpowell/comfyui-lmstudio-image-to-text-node"


### PR DESCRIPTION
Hey! Robin from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!